### PR TITLE
Fix commit graph branch title display

### DIFF
--- a/com.mobi.web/src/main/resources/public/app/history-graph/services/svgelement-helper.service.spec.ts
+++ b/com.mobi.web/src/main/resources/public/app/history-graph/services/svgelement-helper.service.spec.ts
@@ -105,4 +105,16 @@ describe('SVGElementHelperService', () => {
     const svg = service.renderCommitMessage(commitSVGElement, 'dateString');
     expect(svg).toBeTruthy();
   });
+  it('renderBranchLabel truncates long titles and adds tooltip', () => {
+    const branchLabelSVGElement: GitGraphBranch = jasmine.createSpyObj(GitGraphBranch, ['onClick'], {
+      name: 'this-is-a-very-long-branch-title-exceeding-limit'
+    });
+    branchLabelSVGElement.style = branchStyle;
+    const commitLabel: GitGraphCommit = jasmine.createSpyObj(GitGraphCommit, ['onClick']);
+    const svg = service.renderBranchLabel(branchLabelSVGElement, commitLabel);
+    const text = svg.querySelector('text');
+    expect(text.textContent).toContain('...');
+    const title = text.querySelector('title');
+    expect(title.textContent).toBe('this-is-a-very-long-branch-title-exceeding-limit');
+  });
 });

--- a/com.mobi.web/src/main/resources/public/app/history-graph/services/svgelement-helper.service.ts
+++ b/com.mobi.web/src/main/resources/public/app/history-graph/services/svgelement-helper.service.ts
@@ -29,6 +29,7 @@ import { TagStyle } from '@sourceflow/gitgraph-core/lib/template';
 
 const BRANCH_LABEL_PADDING_X = 10;
 const BRANCH_LABEL_PADDING_Y = 4;
+const BRANCH_LABEL_MAX_LENGTH = 20;
 
 const TAG_LABEL_PADDING_X = 10;
 const TAG_LABEL_PADDING_Y = 5;
@@ -113,8 +114,12 @@ export class SVGElementHelperService {
         stroke: gitGraphBranch.style.label.strokeColor || gitGraphBranch.computedColor,
         fill: gitGraphBranch.style.label.bgColor
     });
+    const branchName = commit.commitLabel || gitGraphBranch.name;
+    const displayName = branchName.length > BRANCH_LABEL_MAX_LENGTH
+        ? branchName.substring(0, BRANCH_LABEL_MAX_LENGTH) + '...'
+        : branchName;
     const text = createText({
-        content: commit.commitLabel || gitGraphBranch.name,
+        content: displayName,
         translate: {
             x: BRANCH_LABEL_PADDING_X,
             y: 0
@@ -122,6 +127,11 @@ export class SVGElementHelperService {
         font: gitGraphBranch.style.label.font,
         fill: gitGraphBranch.style.label.color || gitGraphBranch.computedColor
     });
+    if (branchName.length > BRANCH_LABEL_MAX_LENGTH) {
+        const titleElement = document.createElementNS(SVG_NAMESPACE, 'title');
+        titleElement.textContent = branchName;
+        text.appendChild(titleElement);
+    }
     const branchLabel: SVGGElement = document.createElementNS(SVG_NAMESPACE, 'g');
     branchLabel.setAttribute(
         'transform',


### PR DESCRIPTION
## Summary
- truncate branch titles in commit graph
- test branch label truncation and tooltip logic

## Testing
- `npm test` *(fails: ng not found)*
- `mvn -q -pl com.mobi.web -am test` *(fails: mvn not found)*