### PR TITLE
Add default Shapes Graph namespace setting

### DIFF
--- a/com.mobi.namespace.api/src/main/java/com/mobi/namespace/api/NamespaceService.java
+++ b/com.mobi.namespace.api/src/main/java/com/mobi/namespace/api/NamespaceService.java
@@ -23,19 +23,15 @@ package com.mobi.namespace.api;
  * #L%
  */
 
+/**
+ * Marker service used only to load namespace related setting definitions.
+ * <p>
+ * Consumers should obtain namespace values via the {@code ApplicationSettingService}.
+ */
 public interface NamespaceService {
 
     /**
-     * Sets the default ontology namespace to be used by the Application. Must be a valid IRI prefix.
-     *
-     * @param namespace The default ontology to be used by the application.
+     * Fallback namespace used when no application setting is defined.
      */
-    void setDefaultOntologyNamespace(String namespace);
-
-    /**
-     * Retrieves the default ontology namespace.
-     *
-     * @return String The default ontology namespace.
-     */
-    String getDefaultOntologyNamespace();
+    String DEFAULT_ONTOLOGY_NAMESPACE = "https://mobi.com/ontologies/";
 }

--- a/com.mobi.namespace.api/src/main/resources/namespace.ttl
+++ b/com.mobi.namespace.api/src/main/resources/namespace.ttl
@@ -35,5 +35,21 @@
     sh:pattern "(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!127(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?([\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.])+(#|:|\/)$";
     webForm:usesFormField webForm:TextInput .
 
+:DefaultShapesGraphNamespaceApplicationSetting a owl:Class, sh:NodeShape;
+    rdfs:subClassOf setting:ApplicationSetting;
+    dct:description "Default Shapes Graph Namespace";
+    rdfs:comment "An Application Setting an organization can have within the Mobi framework that signifies the namespace to be used for created shapes graph IRIs."@en;
+    sh:property :DefaultShapesGraphNamespaceApplicationSettingPropertyShape;
+    setting:inGroup :NamespaceApplicationSettingGroup .
+
+:DefaultShapesGraphNamespaceApplicationSettingPropertyShape a sh:PropertyShape;
+    sh:path setting:hasDataValue;
+    sh:datatype xsd:string;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:defaultValue "https://mobi.solutions/ontologies/shapes-graph/"@en ;
+    sh:pattern "(?:(?:https?|ftp):\\/\\/)(?:\\S+(?::\\S*)?@)?(?:(?!10(?:\\.\\d{1,3}){3})(?!127(?:\\.\\d{1,3}){3})(?!169\\.254(?:\\.\\d{1,3}){2})(?!192\\.168(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))(?::\\d{2,5})?([\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.])+(#|:|\\/)$";
+    webForm:usesFormField webForm:TextInput .
+
 :NamespaceApplicationSettingGroup a setting:ApplicationSettingGroup ;
     rdfs:label "Namespaces"@en .

--- a/com.mobi.namespace.impl/src/main/java/com/mobi/namespace/impl/NamespaceActivator.java
+++ b/com.mobi.namespace.impl/src/main/java/com/mobi/namespace/impl/NamespaceActivator.java
@@ -36,14 +36,14 @@ import org.osgi.service.component.annotations.Reference;
 import java.io.IOException;
 import java.io.InputStream;
 
-@Component(name = SimpleNamespaceService.COMPONENT_NAME, immediate = true)
-public class SimpleNamespaceService implements NamespaceService {
+@Component(name = NamespaceActivator.COMPONENT_NAME, service = NamespaceService.class, immediate = true)
+public class NamespaceActivator implements NamespaceService {
 
     static final String COMPONENT_NAME = "com.mobi.namespace.api.NamespaceService";
 
     private static final String NAMESPACE_ONTOLOGY_NAME = "http://mobi.com/ontologies/namespace";
     private static final String DEFAULT_NAMESPACE_IRI = "http://mobi.com/ontologies/namespace/DefaultOntologyNamespace/";
-    private String defaultOntologyNamespace = "http://mobi.com/ontologies/";
+
     final ValueFactory vf = new ValidatingValueFactory();
 
     @Reference
@@ -55,15 +55,5 @@ public class SimpleNamespaceService implements NamespaceService {
         InputStream namespaceOntology = NamespaceService.class.getResourceAsStream("/namespace.ttl");
         Model model = settingUtilsService.updateRepoWithSettingDefinitions(namespaceOntology, NAMESPACE_ONTOLOGY_NAME);
         settingUtilsService.initializeApplicationSettingsWithDefaultValues(model, vf.createIRI(DEFAULT_NAMESPACE_IRI));
-    }
-
-    @Override
-    public void setDefaultOntologyNamespace(String namespace) {
-        this.defaultOntologyNamespace = namespace;
-    }
-
-    @Override
-    public String getDefaultOntologyNamespace() {
-        return this.defaultOntologyNamespace;
     }
 }

--- a/com.mobi.ontology.impl.repository/src/main/java/com/mobi/ontology/impl/repository/SimpleOntologyId.java
+++ b/com.mobi.ontology.impl.repository/src/main/java/com/mobi/ontology/impl/repository/SimpleOntologyId.java
@@ -51,12 +51,9 @@ public class SimpleOntologyId implements OntologyId {
         private IRI versionIRI;
         private Model model;
         private final SettingService<ApplicationSetting> settingService;
-        private final NamespaceService namespaceService;
 
-        public Builder(SettingService<ApplicationSetting> settingService,
-                       NamespaceService namespaceService) {
+        public Builder(SettingService<ApplicationSetting> settingService) {
             this.settingService = settingService;
-            this.namespaceService = namespaceService;
         }
 
         /**
@@ -93,7 +90,6 @@ public class SimpleOntologyId implements OntologyId {
 
     private SimpleOntologyId(Builder builder) {
         SettingService<ApplicationSetting> settingService = builder.settingService;
-        NamespaceService namespaceService = builder.namespaceService;
 
         if (builder.model != null) {
             builder.ontologyIRI = null;
@@ -129,7 +125,7 @@ public class SimpleOntologyId implements OntologyId {
                     .getHasDataValue().isPresent()) {
                 ontologyNamespace = ontologyNamespaceApplicationSetting.get().getHasDataValue().get().stringValue();
             } else {
-                ontologyNamespace = namespaceService.getDefaultOntologyNamespace();
+                ontologyNamespace = NamespaceService.DEFAULT_ONTOLOGY_NAMESPACE;
             }
             this.identifier = vf.createIRI(ontologyNamespace + UUID.randomUUID());
         }

--- a/com.mobi.ontology.impl.repository/src/main/java/com/mobi/ontology/impl/repository/SimpleOntologyManager.java
+++ b/com.mobi.ontology.impl.repository/src/main/java/com/mobi/ontology/impl/repository/SimpleOntologyManager.java
@@ -35,7 +35,6 @@ import com.mobi.catalog.api.ontologies.mcat.BranchFactory;
 import com.mobi.catalog.api.ontologies.mcat.InProgressCommit;
 import com.mobi.catalog.config.CatalogConfigProvider;
 import com.mobi.exception.MobiException;
-import com.mobi.namespace.api.NamespaceService;
 import com.mobi.ontology.core.api.Ontology;
 import com.mobi.ontology.core.api.OntologyCreationService;
 import com.mobi.ontology.core.api.OntologyId;
@@ -102,8 +101,6 @@ public class SimpleOntologyManager implements OntologyManager {
     @Reference(target = "(settingType=Application)")
     protected SettingService<ApplicationSetting> settingService;
 
-    @Reference
-    protected NamespaceService namespaceService;
 
     @Reference
     protected OntologyCreationService ontologyCreationService;
@@ -224,22 +221,22 @@ public class SimpleOntologyManager implements OntologyManager {
 
     @Override
     public OntologyId createOntologyId() {
-        return new SimpleOntologyId.Builder(settingService, namespaceService).build();
+        return new SimpleOntologyId.Builder(settingService).build();
     }
 
     @Override
     public OntologyId createOntologyId(Resource resource) {
-        return new SimpleOntologyId.Builder(settingService, namespaceService).id(resource).build();
+        return new SimpleOntologyId.Builder(settingService).id(resource).build();
     }
 
     @Override
     public OntologyId createOntologyId(IRI ontologyIRI) {
-        return new SimpleOntologyId.Builder(settingService, namespaceService).ontologyIRI(ontologyIRI).build();
+        return new SimpleOntologyId.Builder(settingService).ontologyIRI(ontologyIRI).build();
     }
 
     @Override
     public OntologyId createOntologyId(IRI ontologyIRI, IRI versionIRI) {
-        return new SimpleOntologyId.Builder(settingService, namespaceService)
+        return new SimpleOntologyId.Builder(settingService)
                 .ontologyIRI(ontologyIRI)
                 .versionIRI(versionIRI)
                 .build();
@@ -247,7 +244,7 @@ public class SimpleOntologyManager implements OntologyManager {
 
     @Override
     public OntologyId createOntologyId(Model model) {
-        return new SimpleOntologyId.Builder(settingService, namespaceService).model(model).build();
+        return new SimpleOntologyId.Builder(settingService).model(model).build();
     }
 
     protected Optional<Ontology> getOntology(@Nonnull Resource recordId, @Nonnull Resource commitId) {

--- a/com.mobi.ontology.impl.repository/src/test/java/com/mobi/ontology/impl/repository/SimpleOntologyIdTest.java
+++ b/com.mobi.ontology.impl.repository/src/test/java/com/mobi/ontology/impl/repository/SimpleOntologyIdTest.java
@@ -29,7 +29,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.mobi.exception.MobiException;
-import com.mobi.namespace.api.NamespaceService;
 import com.mobi.ontology.core.api.OntologyId;
 import com.mobi.rdf.orm.test.OrmEnabledTestCase;
 import com.mobi.setting.api.SettingService;
@@ -65,8 +64,6 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
     @Mock
     private SettingService<ApplicationSetting> settingService;
 
-    @Mock
-    private NamespaceService namespaceService;
 
     private static final String ONTOLOGY_PREFIX = "http://mobi.com/ontologies/";
 
@@ -78,7 +75,6 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
         mf = getModelFactory();
 
         when(settingService.getSettingByType(any())).thenReturn(Optional.empty());
-        when(namespaceService.getDefaultOntologyNamespace()).thenReturn(ONTOLOGY_PREFIX);
 
         ontologyIRI = vf.createIRI(ontologyIRIString);
         versionIRI = vf.createIRI(versionIRIString);
@@ -96,7 +92,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
     
     @Test
     public void testConstructorWithNoInputValue() {
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).build();
         
         assertTrue(ontologyId.getOntologyIdentifier().stringValue().startsWith(ONTOLOGY_PREFIX));
         assertEquals(Optional.empty(), ontologyId.getOntologyIRI());
@@ -105,7 +101,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
     
     @Test
     public void testConstructorWithOnlyId() {
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).id(identifierIRI).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).id(identifierIRI).build();
         
         assertEquals(identifierIRI, ontologyId.getOntologyIdentifier());
         assertEquals(Optional.empty(), ontologyId.getOntologyIRI());
@@ -114,7 +110,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
     
     @Test
     public void testConstructorWithIdAndOntologyIRI() {
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).id(identifierIRI).ontologyIRI(ontologyIRI).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).id(identifierIRI).ontologyIRI(ontologyIRI).build();
         
         assertEquals(ontologyIRI, ontologyId.getOntologyIdentifier());
         assertEquals(ontologyIRIString, ontologyId.getOntologyIdentifier().stringValue());
@@ -124,7 +120,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
 
     @Test
     public void testConstructorWithIdAndOntologyIRIAndVersionIRI() {
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).id(identifierIRI).ontologyIRI(ontologyIRI).versionIRI(versionIRI).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).id(identifierIRI).ontologyIRI(ontologyIRI).versionIRI(versionIRI).build();
 
         assertEquals(versionIRI, ontologyId.getOntologyIdentifier());
         assertEquals(versionIRIString, ontologyId.getOntologyIdentifier().stringValue());
@@ -136,7 +132,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
 
     @Test
     public void testConstructorWithNoIdAndOntologyIRIAndNoVersionIRI() {
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).ontologyIRI(ontologyIRI).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).ontologyIRI(ontologyIRI).build();
 
         assertEquals(ontologyIRI, ontologyId.getOntologyIdentifier());
         assertEquals(Optional.of(ontologyIRI), ontologyId.getOntologyIRI());
@@ -145,12 +141,12 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
 
     @Test(expected = MobiException.class)
     public void testConstructorWithNoIdAndNoOntologyIRIAndVersionIRI() {
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).versionIRI(versionIRI).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).versionIRI(versionIRI).build();
     }
 
     @Test
     public void testConstructorWithNoIdAndOntologyIRIAndVersionIRI() {
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).ontologyIRI(ontologyIRI).versionIRI(versionIRI).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).ontologyIRI(ontologyIRI).versionIRI(versionIRI).build();
         
         assertEquals(versionIRI, ontologyId.getOntologyIdentifier());
         assertEquals(versionIRIString, ontologyId.getOntologyIdentifier().stringValue());
@@ -164,7 +160,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
     public void testConstructorWithModelNoOntologyIRINoVersionIRI() {
         Model model = mf.createEmptyModel();
 
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).model(model).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).model(model).build();
         assertTrue(ontologyId.getOntologyIdentifier().stringValue().startsWith(ONTOLOGY_PREFIX));
         assertEquals(Optional.empty(), ontologyId.getOntologyIRI());
         assertEquals(Optional.empty(), ontologyId.getVersionIRI());
@@ -175,7 +171,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
         Model model = mf.createEmptyModel();
         model.add(ontologyIRI, typeIRI, ontologyType);
 
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).model(model).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).model(model).build();
         assertEquals(ontologyIRI, ontologyId.getOntologyIdentifier());
         assertEquals(Optional.of(ontologyIRI), ontologyId.getOntologyIRI());
         assertEquals(Optional.empty(), ontologyId.getVersionIRI());
@@ -188,7 +184,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
         model.add(vf.createIRI("urn:secondIRI"), typeIRI, ontologyType);
         model.add(vf.createIRI("urn:thirdIRI"), typeIRI, ontologyType);
 
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).model(model).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).model(model).build();
         assertTrue(ontologyId.getOntologyIRI().isPresent());
         assertTrue(ontologyId.getOntologyIRI().get().equals(ontologyIRI)
                 || ontologyId.getOntologyIRI().get().equals(vf.createIRI("urn:secondIRI"))
@@ -203,7 +199,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
         model.add(ontologyIRI, typeIRI, ontologyType);
         model.add(ontologyIRI, versionIRIPred, versionIRI);
 
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).model(model).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).model(model).build();
         assertEquals(versionIRI, ontologyId.getOntologyIdentifier());
         assertEquals(Optional.of(ontologyIRI), ontologyId.getOntologyIRI());
         assertEquals(Optional.of(versionIRI), ontologyId.getVersionIRI());
@@ -217,7 +213,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
         model.add(vf.createIRI("urn:thirdIRI"), typeIRI, ontologyType);
         model.add(ontologyIRI, versionIRIPred, versionIRI);
 
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).model(model).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).model(model).build();
         if (ontologyId.getVersionIRI().isPresent()) {
             assertEquals(versionIRI, ontologyId.getOntologyIdentifier());
             assertEquals(Optional.of(ontologyIRI), ontologyId.getOntologyIRI());
@@ -236,7 +232,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
         model.add(ontologyIRI, versionIRIPred, versionIRI);
         model.add(ontologyIRI, versionIRIPred, vf.createIRI("urn:secondIRI"));
 
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).model(model).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).model(model).build();
         assertTrue(ontologyId.getVersionIRI().isPresent());
         assertTrue(ontologyId.getVersionIRI().get().equals(versionIRI) || ontologyId.getVersionIRI().get().equals(vf.createIRI("urn:secondIRI")));
         assertEquals(ontologyId.getVersionIRI().get(), ontologyId.getOntologyIdentifier());
@@ -253,7 +249,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
         model.add(ontologyIRI2, typeIRI, ontologyType);
         model.add(ontologyIRI2, versionIRIPred, versionIRI2);
 
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).model(model).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).model(model).build();
         assertTrue(ontologyId.getVersionIRI().isPresent());
         if (ontologyId.getVersionIRI().get().equals(versionIRI)) {
             assertEquals(versionIRI, ontologyId.getOntologyIdentifier());
@@ -270,7 +266,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
     public void testConstructorWithModelOntologyIRIandID() {
         Model model = mf.createEmptyModel();
         model.add(ontologyIRI, typeIRI, ontologyType);
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).id(identifierIRI).model(model).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).id(identifierIRI).model(model).build();
 
         assertEquals(ontologyIRI, ontologyId.getOntologyIdentifier());
         assertEquals(ontologyIRIString, ontologyId.getOntologyIdentifier().stringValue());
@@ -283,7 +279,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
         Model model = mf.createEmptyModel();
         model.add(ontologyIRI, versionIRIPred, versionIRI);
 
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).model(model).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).model(model).build();
         assertTrue(ontologyId.getOntologyIdentifier().stringValue().startsWith(ONTOLOGY_PREFIX));
         assertEquals(Optional.empty(), ontologyId.getOntologyIRI());
         assertEquals(Optional.empty(), ontologyId.getVersionIRI());
@@ -294,7 +290,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
         Model model = mf.createEmptyModel();
         model.add(ontologyIRI, typeIRI, ontologyType);
 
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).model(model).ontologyIRI(vf.createIRI("urn:otherOntologyIRI")).versionIRI(vf.createIRI("urn:otherVersionIRI")).id(identifierIRI).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).model(model).ontologyIRI(vf.createIRI("urn:otherOntologyIRI")).versionIRI(vf.createIRI("urn:otherVersionIRI")).id(identifierIRI).build();
         assertEquals(ontologyIRI, ontologyId.getOntologyIdentifier());
         assertEquals(Optional.of(ontologyIRI), ontologyId.getOntologyIRI());
         assertEquals(Optional.empty(), ontologyId.getVersionIRI());
@@ -306,7 +302,7 @@ public class SimpleOntologyIdTest extends OrmEnabledTestCase  {
         model.add(vf.createBNode("node123"), typeIRI, ontologyType);
         model.add(vf.createBNode("node123"), vf.createIRI("urn:testPred"), vf.createLiteral("test value"));
 
-        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService, namespaceService).model(model).build();
+        OntologyId ontologyId = new SimpleOntologyId.Builder(settingService).model(model).build();
         assertTrue(ontologyId.getOntologyIdentifier().stringValue().startsWith(ONTOLOGY_PREFIX));
         assertEquals(Optional.empty(), ontologyId.getOntologyIRI());
         assertEquals(Optional.empty(), ontologyId.getVersionIRI());

--- a/com.mobi.ontology.impl.repository/src/test/java/com/mobi/ontology/impl/repository/SimpleOntologyTest.java
+++ b/com.mobi.ontology.impl.repository/src/test/java/com/mobi/ontology/impl/repository/SimpleOntologyTest.java
@@ -46,7 +46,6 @@ import com.mobi.catalog.config.CatalogConfigProvider;
 import com.mobi.dataset.api.DatasetUtilsService;
 import com.mobi.dataset.impl.SimpleDatasetRepositoryConnection;
 import com.mobi.dataset.ontology.dataset.Dataset;
-import com.mobi.namespace.api.NamespaceService;
 import com.mobi.ontology.core.api.AnnotationProperty;
 import com.mobi.ontology.core.api.DataProperty;
 import com.mobi.ontology.core.api.Hierarchy;
@@ -175,8 +174,6 @@ public class SimpleOntologyTest extends OrmEnabledTestCase {
     @Mock
     private SettingService<ApplicationSetting> settingService;
 
-    @Mock
-    private NamespaceService namespaceService;
 
     @Before
     public void setUp() throws Exception {
@@ -209,7 +206,7 @@ public class SimpleOntologyTest extends OrmEnabledTestCase {
         when(ontologyManager.createOntologyId(any(IRI.class), any(IRI.class))).thenReturn(ontologyId);
         when(ontologyManager.createOntologyId(any(IRI.class))).thenReturn(ontologyId);
         ArgumentCaptor<Model> iriModel = ArgumentCaptor.forClass(Model.class);
-        when(ontologyManager.createOntologyId(iriModel.capture())).thenAnswer(invocation -> new SimpleOntologyId.Builder(settingService, namespaceService).model(iriModel.getValue()).build());
+        when(ontologyManager.createOntologyId(iriModel.capture())).thenAnswer(invocation -> new SimpleOntologyId.Builder(settingService).model(iriModel.getValue()).build());
         when(importsResolver.getRecordIRIFromOntologyIRI(any(Resource.class))).thenReturn(Optional.empty());
         when(ontologyId.getOntologyIdentifier()).thenReturn(vf.createIRI("https://mobi.com/ontology-id"));
 

--- a/com.mobi.shapes.api/src/main/java/com/mobi/shapes/api/record/AbstractShapesGraphRecordService.java
+++ b/com.mobi.shapes.api/src/main/java/com/mobi/shapes/api/record/AbstractShapesGraphRecordService.java
@@ -34,7 +34,10 @@ import com.mobi.catalog.api.record.statistic.Statistic;
 import com.mobi.catalog.api.record.statistic.StatisticDefinition;
 import com.mobi.exception.MobiException;
 import com.mobi.jaas.api.ontologies.usermanagement.User;
+import com.mobi.namespace.api.ontologies.DefaultShapesGraphNamespaceApplicationSetting;
 import com.mobi.ontology.utils.OntologyModels;
+import com.mobi.setting.api.SettingService;
+import com.mobi.setting.api.ontologies.setting.ApplicationSetting;
 import com.mobi.shapes.api.ShapesGraphManager;
 import com.mobi.shapes.api.ontologies.shapesgrapheditor.ShapesGraphRecord;
 import org.apache.commons.io.IOUtils;
@@ -54,6 +57,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Semaphore;
 
@@ -68,12 +72,15 @@ public abstract class AbstractShapesGraphRecordService<T extends ShapesGraphReco
     @Reference
     public ShapesGraphManager shapesGraphManager;
 
+    @Reference(target = "(settingType=Application)")
+    protected SettingService<ApplicationSetting> settingService;
+
     /**
      * Semaphore for protecting shapes graph IRI uniqueness checks.
      */
     private final Semaphore semaphore = new Semaphore(1, true);
 
-    public static final String DEFAULT_PREFIX = "http://mobi.com/ontologies/shapes-graph/";
+    public static final String DEFAULT_PREFIX = "https://mobi.solutions/ontologies/shapes-graph/";
 
     static {
         try {
@@ -160,13 +167,22 @@ public abstract class AbstractShapesGraphRecordService<T extends ShapesGraphReco
                 .forEach(ontologyDefinitions::addAll);
 
         Resource ontologyIRI = OntologyModels.findFirstOntologyIRI(ontologyDefinitions)
-                .orElse(vf.createIRI(DEFAULT_PREFIX + UUID.randomUUID()));
+                .orElse(vf.createIRI(getShapesGraphNamespace() + UUID.randomUUID()));
 
         conn.add(ontologyIRI,  RDF.TYPE, OWL.ONTOLOGY, headGraph);
 
         validateShapesGraph(ontologyIRI);
         record.setTrackedIdentifier(ontologyIRI);
         thingManager.updateObject(record, conn);
+    }
+
+    private String getShapesGraphNamespace() {
+        Optional<ApplicationSetting> namespaceSetting = settingService.getSettingByType(
+                vf.createIRI(DefaultShapesGraphNamespaceApplicationSetting.TYPE));
+        if (namespaceSetting.isPresent() && namespaceSetting.get().getHasDataValue().isPresent()) {
+            return namespaceSetting.get().getHasDataValue().get().stringValue();
+        }
+        return DEFAULT_PREFIX;
     }
 
     /**

--- a/com.mobi.web/src/main/resources/public/app/shared/services/settingManager.service.ts
+++ b/com.mobi.web/src/main/resources/public/app/shared/services/settingManager.service.ts
@@ -51,6 +51,8 @@ export class SettingManagerService {
     defaultOntologyNamespaceSetting = 'http://mobi.com/ontologies/namespace#DefaultOntologyNamespaceApplicationSetting';
     defaultOntologyNamespacePropertyShape = 'http://mobi.com/ontologies/namespace#DefaultOntologyNamespaceApplication'
         + 'SettingPropertyShape';
+    defaultShapesGraphNamespaceSetting = 'http://mobi.com/ontologies/namespace#DefaultShapesGraphNamespaceApplicationSetting';
+    defaultShapesGraphNamespacePropertyShape = 'http://mobi.com/ontologies/namespace#DefaultShapesGraphNamespaceApplicationSettingPropertyShape';
 
     constructor(private http: HttpClient, private toast: ToastService, private spinnerSvc: ProgressSpinnerService) {}
 
@@ -78,6 +80,52 @@ export class SettingManagerService {
                     switchMap(response => {
                         const newArray = response.filter(el => {
                             return el['@id'] === this.defaultOntologyNamespacePropertyShape;
+                        });
+                        if (newArray.length !== 1) {
+                            this.toast.createErrorToast(`Number of matching property shapes must be one, not ${newArray.length}`);
+                            return throwError('');
+                        }
+                        const defaultNamespacePropertyShape = newArray[0];
+                        if (has(defaultNamespacePropertyShape, `${SHACL}defaultValue`)) {
+                            return of(getPropertyValue(defaultNamespacePropertyShape, `${SHACL}defaultValue`));
+                        } else {
+                            this.toast.createErrorToast('No default value found for default namespace');
+                            return throwError('');
+                        }
+                    }),
+                    catchError(() => {
+                        this.toast.createErrorToast('Could not retrieve setting definitions');
+                        return throwError('');
+                    })
+                );
+            }),
+        );
+    }
+
+    getDefaultShapesGraphNamespace(): Observable<string> {
+        return this.getApplicationSettingByType(this.defaultShapesGraphNamespaceSetting).pipe(
+            switchMap(response => {
+                const applicationSetting = response;
+                if (applicationSetting.length > 1) {
+                    this.toast.createErrorToast('Too many values present for application setting');
+                    return throwError('');
+                } else if (applicationSetting.length === 1) {
+                    const defaultNamespace = applicationSetting[0];
+                    if (has(defaultNamespace, SettingConstants.HAS_DATA_VALUE)) {
+                        return of(getPropertyValue(defaultNamespace, SettingConstants.HAS_DATA_VALUE));
+                    }
+                    return throwError('');
+                } else {
+                    this.toast.createErrorToast('No values found for application setting. For some reason, endpoint '
+                        + 'did not return error.');
+                    return throwError('');
+                }
+            }),
+            catchError(() => {
+                return this.getApplicationSettingDefinitions(this.namespaceGroup).pipe(
+                    switchMap(response => {
+                        const newArray = response.filter(el => {
+                            return el['@id'] === this.defaultShapesGraphNamespacePropertyShape;
                         });
                         if (newArray.length !== 1) {
                             this.toast.createErrorToast(`Number of matching property shapes must be one, not ${newArray.length}`);

--- a/com.mobi.web/src/main/resources/public/app/shared/services/shapesGraphState.service.spec.ts
+++ b/com.mobi.web/src/main/resources/public/app/shared/services/shapesGraphState.service.spec.ts
@@ -47,6 +47,7 @@ import { ShapesGraphListItem } from '../models/shapesGraphListItem.class';
 import { ShapesGraphManagerService } from './shapesGraphManager.service';
 import { StateManagerService } from './stateManager.service';
 import { ToastService } from './toast.service';
+import { SettingManagerService } from './settingManager.service';
 import { VersionedRdfStateBase } from '../models/versionedRdfStateBase.interface';
 import { VersionedRdfUploadResponse } from '../models/versionedRdfUploadResponse.interface';
 import { ShapesGraphStateService } from './shapesGraphState.service';
@@ -58,6 +59,7 @@ describe('Shapes Graph State service', function() {
   let policyEnforcementStub: jasmine.SpyObj<PolicyEnforcementService>;
   let shapesGraphManagerStub: jasmine.SpyObj<ShapesGraphManagerService>;
   let toastStub: jasmine.SpyObj<ToastService>;
+  let settingManagerStub: jasmine.SpyObj<SettingManagerService>;
   let _catalogManagerActionSubject: Subject<EventWithPayload>;
   let _mergeRequestManagerActionSubject: Subject<EventWithPayload>;
 
@@ -85,7 +87,8 @@ describe('Shapes Graph State service', function() {
         MockProvider(PolicyManagerService),
         MockProvider(ShapesGraphManagerService),
         MockProvider(StateManagerService),
-        MockProvider(ToastService)
+        MockProvider(ToastService),
+        MockProvider(SettingManagerService)
       ]
     });
     shapesGraphManagerStub = TestBed.inject(ShapesGraphManagerService) as jasmine.SpyObj<ShapesGraphManagerService>;
@@ -97,6 +100,8 @@ describe('Shapes Graph State service', function() {
 
     mergeRequestManagerServiceStub = TestBed.inject(MergeRequestManagerService) as jasmine.SpyObj<MergeRequestManagerService>;
     toastStub = TestBed.inject(ToastService) as jasmine.SpyObj<ToastService>;
+    settingManagerStub = TestBed.inject(SettingManagerService) as jasmine.SpyObj<SettingManagerService>;
+    settingManagerStub.getDefaultShapesGraphNamespace.and.returnValue(of('http://mobi.solutions/ontologies/shapes-graph/'));
     catalogManagerStub = TestBed.inject(CatalogManagerService) as jasmine.SpyObj<CatalogManagerService>;
     catalogManagerStub.localCatalog = {'@id': catalogId, '@type': []};
     
@@ -117,6 +122,7 @@ describe('Shapes Graph State service', function() {
     shapesGraphManagerStub = null;
     catalogManagerStub = null;
     policyEnforcementStub = null;
+    settingManagerStub = null;
     _catalogManagerActionSubject = null;
     _mergeRequestManagerActionSubject = null;
   });
@@ -125,8 +131,9 @@ describe('Shapes Graph State service', function() {
     expect(service['catalogId']).toEqual(catalogId);
   });
   it('getDefaultNamespace provides the default namespace to be used for new shapes graphs', fakeAsync(function() {
+    settingManagerStub.getDefaultShapesGraphNamespace.and.returnValue(of('http://example.com/shapes-graph/'));
     service.getDefaultNamespace().subscribe(value => {
-      expect(value).toContain('shapes-graph');
+      expect(value).toEqual('http://example.com/shapes-graph/');
     });
     tick();
   }));

--- a/com.mobi.web/src/main/resources/public/app/shared/services/shapesGraphState.service.ts
+++ b/com.mobi.web/src/main/resources/public/app/shared/services/shapesGraphState.service.ts
@@ -44,6 +44,7 @@ import { PolicyEnforcementService } from './policyEnforcement.service';
 import { getBeautifulIRI, getDctermsValue, getPropertyId } from '../utility';
 import { XACMLRequest } from '../models/XACMLRequest.interface';
 import { MergeRequestManagerService } from './mergeRequestManager.service';
+import { SettingManagerService } from './settingManager.service';
 import { EventPayload, EventTypeConstants, EventWithPayload } from '../models/eventWithPayload.interface';
 import { RdfDownload } from '../models/rdfDownload.interface';
 import { RdfUpdate } from '../models/rdfUpdate.interface';
@@ -64,7 +65,8 @@ export class ShapesGraphStateService extends VersionedRdfState<ShapesGraphListIt
               protected toast: ToastService,
               protected pep: PolicyEnforcementService,
               private pm: PolicyManagerService,
-              private sgm: ShapesGraphManagerService) {
+              private sgm: ShapesGraphManagerService,
+              private stm: SettingManagerService) {
     super(SHAPESGRAPHSTATE,
       BRANCHID,
       TAGID,
@@ -160,7 +162,7 @@ export class ShapesGraphStateService extends VersionedRdfState<ShapesGraphListIt
    * Returns the namespace to be used for new ShapesGraphRecords
    */
   getDefaultNamespace(): Observable<string> {
-    return of('http://mobi.solutions/ontologies/shapes-graph/');
+    return this.stm.getDefaultShapesGraphNamespace();
   }
   /**
    * Returns the display name of an entity within the currently selected ShapesGraphRecord. Currently just returns the


### PR DESCRIPTION
## Summary
- add `DefaultShapesGraphNamespaceApplicationSetting` shapes
- look up the default shapes graph namespace when creating shapes graphs
- expose the setting via SettingManagerService
- use SettingManagerService in ShapesGraphStateService
- update ShapesGraphStateService tests
- turn namespace service into activator loading setting definitions only
- remove namespace service usages in ontology components
- use new `https://mobi.solutions` default namespace

## Testing
- `npm test` *(fails: ng not found)*
- `mvn -q test` *(fails: mvn not found)*